### PR TITLE
Specify dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
   license="ASF",
   packages=["sightseer"],
   install_requires=[
-      "tensorflow",
+      "tensorflow==1.15.4",
       "pillow",
       "opencv-python",
       "wget",

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,13 @@ setup(
   author_email="mail.rishabh.anand@gmail.com",
   license="ASF",
   packages=["sightseer"],
+  install_requires=[
+      "tensorflow",
+      "pillow",
+      "opencv-python",
+      "wget",
+      "pandas",
+      "matplotlib"
+  ],
   zip_safe=False
 )


### PR DESCRIPTION
Specifying the project dependencies using the [`install_requires` keyword](https://packaging.python.org/discussions/install-requires-vs-requirements/) should allow users to install the required dependencies as they install `sightseer` via pip.